### PR TITLE
feat(gha): add symlink-map schema

### DIFF
--- a/schemas/gha/index.json
+++ b/schemas/gha/index.json
@@ -1,0 +1,13 @@
+{
+  "name": "gha",
+  "description": "Schemas for GitHub Actions in arustydev/gha",
+  "schemas": [
+    {
+      "name": "symlink-map",
+      "description": "Configuration for symlink-map GitHub Action",
+      "versions": ["v1"],
+      "latest": "v1",
+      "path": "symlink-map/v1.schema.json"
+    }
+  ]
+}

--- a/schemas/gha/symlink-map/v1.schema.json
+++ b/schemas/gha/symlink-map/v1.schema.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.arusty.dev/gha/symlink-map/v1.schema.json",
+  "title": "Symlink Map Configuration",
+  "description": "Configuration for symlink-map GitHub Action. Supports explicit links array or books mapping format.",
+  "type": "object",
+  "oneOf": [
+    { "required": ["links"] },
+    { "required": ["books"] }
+  ],
+  "properties": {
+    "links": {
+      "type": "array",
+      "description": "Explicit list of symlinks to create",
+      "items": {
+        "type": "object",
+        "required": ["source", "target"],
+        "properties": {
+          "source": {
+            "type": "string",
+            "description": "Source path (must exist)",
+            "minLength": 1
+          },
+          "target": {
+            "type": "string",
+            "description": "Target symlink path",
+            "minLength": 1
+          }
+        },
+        "additionalProperties": false
+      },
+      "minItems": 1
+    },
+    "books": {
+      "type": "object",
+      "description": "Book sources mapping (sources.yml format)",
+      "additionalProperties": {
+        "type": "object",
+        "required": ["repo", "path"],
+        "properties": {
+          "repo": {
+            "type": "string",
+            "description": "GitHub repository (owner/repo)",
+            "pattern": "^[a-zA-Z0-9_-]+/[a-zA-Z0-9_.-]+$"
+          },
+          "path": {
+            "type": "string",
+            "description": "Path within repository",
+            "minLength": 1
+          },
+          "ref": {
+            "type": "string",
+            "description": "Git ref (branch/tag)",
+            "default": "main"
+          },
+          "title": {
+            "type": "string",
+            "description": "Display title for this source"
+          }
+        },
+        "additionalProperties": false
+      },
+      "minProperties": 1
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add JSON schema for `symlink-map` GitHub Action configuration
- Add `gha/` category with index file

## Schema Details

The schema supports two formats:

### 1. Explicit Links Array
```yaml
links:
  - source: .sources/ai/docs/src
    target: books/ai
```

### 2. Books Format (sources.yml style)
```yaml
books:
  ai:
    repo: arustydev/ai
    path: docs/src
    ref: main
    title: "AI Configuration"
```

## Validation

- Validates `repo` format matches `owner/repo` pattern
- Requires `source` and `target` for links
- Requires `repo` and `path` for books entries
- Enforces `oneOf` - must use either `links` or `books`, not both

## Served At

`https://schemas.arusty.dev/gha/symlink-map/v1.schema.json`

## Related

- Closes #4
- arustydev/gha#5 - symlink-map action